### PR TITLE
Enhancements to chaperone.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,5 @@ RUN sed -i -e "s/graylog2-server.uris=.*$/graylog2-server.uris=\"http:\/\/127.0.
 EXPOSE 9000 12201/udp 12900 2812
 
 COPY chaperone.conf /etc/chaperone.d/chaperone.conf
-COPY ./start.sh start.sh
+COPY ./setup.sh setup.sh
 ENTRYPOINT ["/usr/local/bin/chaperone"]
-

--- a/Dockerfile-allinone
+++ b/Dockerfile-allinone
@@ -4,7 +4,7 @@ MAINTAINER Mihai Bivol <mihai.bivol@eaudeweb.ro>
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 RUN echo 'deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen' > /etc/apt/sources.list.d/mongodb.list
 RUN apt-get update -q && \
-    apt-get install wget sudo netcat python3-pip -y && \
+    apt-get install wget sudo netcat python3-pip monit --no-install-recommends -y && \
     apt-get clean && \
     pip3 install chaperone
 
@@ -12,7 +12,7 @@ RUN mkdir -p /data /logs /conf /etc/chaperone.d
 
 WORKDIR /opt
 
-ENV GRAYLOG_VERSION="1.2.1"
+ENV GRAYLOG_VERSION="1.2.2"
 ENV ES_VERSION="1.7.3"
 
 # Get mongo
@@ -48,5 +48,5 @@ RUN sed -i -e "s/graylog2-server.uris=.*$/graylog2-server.uris=\"http:\/\/127.0.
 EXPOSE 9000 12201/udp 12900
 
 COPY chaperone.conf /etc/chaperone.d/chaperone.conf
-COPY ./start.sh start.sh
+COPY ./setup.sh setup.sh
 ENTRYPOINT ["/usr/local/bin/chaperone"]

--- a/chaperone.conf
+++ b/chaperone.conf
@@ -1,3 +1,135 @@
-startup.service: {
-  command: "/opt/start.sh"
+# Chaperone Start-up
+
+#
+#  Global Settings
+#
+
+settings: {
+
+  env_set: {
+
+    # If not defined, create a sensible set of services.   Note that services such as monit, mongodb
+    # and elasticsearch are defined, but are declared optional in their service definitions so that
+    # they will not start if they are not installed as part of the container image.
+
+    ENABLED_SERVICES: "${ENABLED_SERVICES:-graylog-web,graylog-server,monit,mongodb,elasticsearch}",
+
+    # Derive individual enable variables.  The _SERVLIST variable formats ENABLED_SERVICES in a way that makes
+    # it easy to create booleans reliably.  The leading underscore means it won't be passed to processes.
+
+    _SERVLIST: ",${ENABLED_SERVICES},",     # This is used so our "enable" searches work using ",keyword,"
+
+    ENABLE_ES:     "${_SERVLIST:|*,elasticsearch,*|true|false}",
+    ENABLE_MONGO:  "${_SERVLIST:|*,mongodb,*|true|false}",
+    ENABLE_WEB:    "${_SERVLIST:|*,graylog-web,*|true|false}",
+    ENABLE_SERVER: "${_SERVLIST:|*,graylog-server,*|true|false}",
+    ENABLE_MONIT:  "${_SERVLIST:|*,monit,*|true|false}",
+  }
+}
+
+#
+# Logging
+#
+# Chaperone will capture all logs from all processes which use standard /dev/log logging,
+# and output it to stdout (this is the usual Docker way).  Other options are to send logs
+# to files, or to remote syslog servers if desired.   Multiple logging sections can be
+# defined to send particular types of log output to different places.
+#
+# For more information on how to configure logging, see:
+# http://garywiz.github.io/chaperone/ref/config-logging.html
+#
+
+console.logging: {
+  selector: '*.warn',
+  stdout: true,
+}
+
+#
+# Initialization script.
+#
+# The setup.sh script runs before any other activity (because it's part of the INIT group), and container
+# start-up will not proceed if it doesn't complete successfully.  The initialization script will be passed
+# all environment variables, and should prepare a new or existing container for service start-up.
+#
+
+setup.service: {
+  command: "/opt/setup.sh",
+  service_groups: INIT,
+}
+
+#
+# SERVICE DEFINITIONS
+#
+# This section consists of both optional and required services which declare dependencies.  Optional
+# services won't be started if their executables don't exist, but still allow their dependents to start.
+# When possible, Chaperone will start services simultaneously.   Services which fail will prevent
+# further startup and terminate the container with a logged error message.
+#
+# When possible, services use a PID file so that Chaperone can determine whether the service
+# has successfully started.
+#
+
+# Optional Service: Elasticsearch
+
+elasticsearch.service: {
+  enabled: "${ENABLE_ES}",
+  optional: true,
+  type: forking,
+  uid: elasticsearch,
+  command: "/opt/elasticsearch/bin/elasticsearch 
+         -Des.path.data=/data/elasticsearc 
+         -Des.path.data=/data/elasticsearch 
+         -Des.cluster.name=graylog2 
+         -Des.path.logs=/logs/elasticsearch/ 
+         -p /var/run/elasticsearch.pid -d",
+  pidfile: "/var/run/elasticsearch.pid",
+}
+
+# Optional Service: MongoDB
+
+mongodb.service: {
+  enabled: "${ENABLE_MONGO}",
+  optional: true,
+  type: forking,
+  command: "/usr/bin/mongod
+         --dbpath=/data/mongodb
+         --smallfiles --quiet --logappend
+         --logpath=/logs/mongodb/mongodb.log
+	 --pidfilepath /var/run/mongodb.pid
+         --fork",
+  pidfile: "/var/run/mongodb.pid",
+  uid: mongodb,
+}
+
+# Service: Greylog2
+# (starts after elasticsearch and mongodb successfuly start)
+
+greylog2.service: {
+  enabled: "${ENABLE_SERVER}",
+  type: forking,
+  command: "/opt/graylog2-server/bin/graylogctl start",
+  pidfile: "/tmp/graylog.pid",
+  process_timeout: 90,		# NOTE: greylog appears to take a long time to start sometimes.
+  after: "mongodb.service, elasticsearch.service",
+}
+  
+# Service: greylog-web
+# (starts after Greylog2 is running)
+
+greylog-web.service: {
+  enabled: "${ENABLE_WEB}",
+  command: "/opt/graylog2-web-interface/bin/graylog-web-interface",
+  after: greylog2.service,
+}
+
+# Optional Service: monit
+# Starts after greylog2 and grelog-web, if installed.
+
+monit.service: {
+  enabled: "${ENABLE_MONIT}",
+  optional: true,
+  type: forking,
+  command: "monit -c /etc/monit/monitrc",
+  pidfile: "/var/run/monit.pid",
+  after: "greylog2.service, greylog-web.service",
 }


### PR DESCRIPTION
I noticed that you're using chaperone now as the init process for this container (I got a Google alert on it some time ago).  I'm the author of chaperone, and like to try now and then to be sure it works well in various use-cases.  So, I enhanced your project by moving all the service startup and management into `chaperone.conf`.   I tried to preserve all operation so that the existing documentation and methods of use are identical, but did minimal testing, mostly the "allinone" container, to be sure everything is working.  

Some of the advantages:
1.  Process start-up is now managed using PID-files and dependencies, so there is no need for "sleep" calls or to use `nc` to determine if processes are ready.
2.  Optional services like elasticsearch or monit will not be started if they aren't installed.
3.  Better logging to stdout (this is configurable).
4.  Faster, cleaner shutdown since Chaperone knows all processes and their state and shuts them down in an organised fashion.
5.  Possibly easier to maintain than the original start.sh script.

I've included complete documentation on the changes in the `chaperone.conf` file itself.

If you run these containers, you can see a compete detailed log of how start-up proceeds if you use the `--debug` switch like this:

```
docker run -e GRAYLOG_PASSWORD=password -p 9000:9000 graylog2-all --debug
```

... and can have a shell run so you can inspect the container after start-up like this ...

```
docker run -e GRAYLOG_PASSWORD=password -p 9000:9000 graylog2-all --debug /bin/bash
```

I noted you have many docker containers, and I thought this might be a useful template at least.   My main purpose was just to test chaperone in your situation, so whether you use this or not is, of course, up to you.
